### PR TITLE
[SYCL] Implement decorated enum class

### DIFF
--- a/sycl/include/CL/sycl/access/access.hpp
+++ b/sycl/include/CL/sycl/access/access.hpp
@@ -58,6 +58,7 @@ enum class address_space : int {
   generic_space = 6, // TODO generic_space address space is not supported yet
 };
 
+enum class decorated { no = 0, yes = 1, legacy = 2 };
 } // namespace access
 
 using access::target;


### PR DESCRIPTION
Added enum class sycl::access::decorated to access.hpp, so it would be possible to perform tests demanding this implementation.