### PR TITLE
Update atomic.hpp

### DIFF
--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -168,7 +168,8 @@ namespace sycl {
 
 template <typename T, access::address_space addressSpace =
                           access::address_space::global_space>
-class atomic {
+class __SYCL2020_DEPRECATED(
+    "sycl::atomic is deprecated since SYCL 2020") atomic {
   friend class atomic<T, access::address_space::global_space>;
   static_assert(detail::IsValidAtomicType<T>::value,
                 "Invalid SYCL atomic type. Valid types are: int, "

--- a/sycl/test/regression/atomic_deprecated.cpp
+++ b/sycl/test/regression/atomic_deprecated.cpp
@@ -1,0 +1,10 @@
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+
+#include <sycl/sycl.hpp>
+int main() {
+  cl::sycl::multi_ptr<int, cl::sycl::access::address_space::global_space> a(
+      nullptr);
+  // expected-warning@+1 {{'atomic<int, sycl::access::address_space::global_space>' is deprecated: sycl::atomic is deprecated since SYCL 2020}}
+  cl::sycl::atomic<int> b(a);
+  return 0;
+}


### PR DESCRIPTION
cl::sycl::atomic was marked as deprecated to meet new SYCL standart.